### PR TITLE
Remove vendored libraries from `libraries` in podspec.

### DIFF
--- a/OpenSSL-Universal.podspec
+++ b/OpenSSL-Universal.podspec
@@ -38,6 +38,5 @@ Pod::Spec.new do |s|
   s.osx.preserve_paths      = 'lib-macos/libcrypto.a', 'lib-macos/libssl.a'
   s.osx.vendored_libraries  = 'lib-macos/libcrypto.a', 'lib-macos/libssl.a'
 
-  s.libraries = 'ssl', 'crypto'
   s.requires_arc = false
 end


### PR DESCRIPTION
- The `libraries` command is only for system libraries, not vendored libraries.
- Resolves issues where nested Podfile targets try to link against the vendored libraries when they shouldn't.
- Fixes #54 & #58