### PR TITLE
fix documentation issue / build warning

### DIFF
--- a/Frameworks/ios/OpenSSL.framework/Headers/ecdsa.h
+++ b/Frameworks/ios/OpenSSL.framework/Headers/ecdsa.h
@@ -288,19 +288,19 @@ void ECDSA_METHOD_set_verify(ECDSA_METHOD *ecdsa_method,
                                                      const ECDSA_SIG *sig,
                                                      EC_KEY *eckey));
 
-void ECDSA_METHOD_set_flags(ECDSA_METHOD *ecdsa_method, int flags);
-
 /**  Set the flags field in the ECDSA_METHOD
  *   \param  ecdsa_method  pointer to existing ECDSA_METHOD
  *   \param  flags flags value to set
  */
 
-void ECDSA_METHOD_set_name(ECDSA_METHOD *ecdsa_method, char *name);
+void ECDSA_METHOD_set_flags(ECDSA_METHOD *ecdsa_method, int flags);
 
 /**  Set the name field in the ECDSA_METHOD
  *   \param  ecdsa_method  pointer to existing ECDSA_METHOD
  *   \param  name name to set
  */
+
+void ECDSA_METHOD_set_name(ECDSA_METHOD *ecdsa_method, char *name);
 
 /* BEGIN ERROR CODES */
 /*

--- a/Frameworks/macos/OpenSSL.framework/Versions/A/Headers/ecdsa.h
+++ b/Frameworks/macos/OpenSSL.framework/Versions/A/Headers/ecdsa.h
@@ -288,19 +288,19 @@ void ECDSA_METHOD_set_verify(ECDSA_METHOD *ecdsa_method,
                                                      const ECDSA_SIG *sig,
                                                      EC_KEY *eckey));
 
-void ECDSA_METHOD_set_flags(ECDSA_METHOD *ecdsa_method, int flags);
-
 /**  Set the flags field in the ECDSA_METHOD
  *   \param  ecdsa_method  pointer to existing ECDSA_METHOD
  *   \param  flags flags value to set
  */
 
-void ECDSA_METHOD_set_name(ECDSA_METHOD *ecdsa_method, char *name);
+void ECDSA_METHOD_set_flags(ECDSA_METHOD *ecdsa_method, int flags);
 
 /**  Set the name field in the ECDSA_METHOD
  *   \param  ecdsa_method  pointer to existing ECDSA_METHOD
  *   \param  name name to set
  */
+
+void ECDSA_METHOD_set_name(ECDSA_METHOD *ecdsa_method, char *name);
 
 /* BEGIN ERROR CODES */
 /*

--- a/ios/include/openssl/ecdsa.h
+++ b/ios/include/openssl/ecdsa.h
@@ -288,19 +288,19 @@ void ECDSA_METHOD_set_verify(ECDSA_METHOD *ecdsa_method,
                                                      const ECDSA_SIG *sig,
                                                      EC_KEY *eckey));
 
-void ECDSA_METHOD_set_flags(ECDSA_METHOD *ecdsa_method, int flags);
-
 /**  Set the flags field in the ECDSA_METHOD
  *   \param  ecdsa_method  pointer to existing ECDSA_METHOD
  *   \param  flags flags value to set
  */
 
-void ECDSA_METHOD_set_name(ECDSA_METHOD *ecdsa_method, char *name);
+void ECDSA_METHOD_set_flags(ECDSA_METHOD *ecdsa_method, int flags);
 
 /**  Set the name field in the ECDSA_METHOD
  *   \param  ecdsa_method  pointer to existing ECDSA_METHOD
  *   \param  name name to set
  */
+ 
+void ECDSA_METHOD_set_name(ECDSA_METHOD *ecdsa_method, char *name);
 
 /* BEGIN ERROR CODES */
 /*

--- a/macos/include/openssl/ecdsa.h
+++ b/macos/include/openssl/ecdsa.h
@@ -288,19 +288,19 @@ void ECDSA_METHOD_set_verify(ECDSA_METHOD *ecdsa_method,
                                                      const ECDSA_SIG *sig,
                                                      EC_KEY *eckey));
 
-void ECDSA_METHOD_set_flags(ECDSA_METHOD *ecdsa_method, int flags);
-
 /**  Set the flags field in the ECDSA_METHOD
  *   \param  ecdsa_method  pointer to existing ECDSA_METHOD
  *   \param  flags flags value to set
  */
 
-void ECDSA_METHOD_set_name(ECDSA_METHOD *ecdsa_method, char *name);
+void ECDSA_METHOD_set_flags(ECDSA_METHOD *ecdsa_method, int flags);
 
 /**  Set the name field in the ECDSA_METHOD
  *   \param  ecdsa_method  pointer to existing ECDSA_METHOD
  *   \param  name name to set
  */
+ 
+void ECDSA_METHOD_set_name(ECDSA_METHOD *ecdsa_method, char *name);
 
 /* BEGIN ERROR CODES */
 /*


### PR DESCRIPTION
The documentation in `ecdsa.h` causes an build warning in XCode for the methods: 
- ECDSA_METHOD_set_flags
- ECDSA_METHOD_set_name

The documentation is beyond the methods and not above.
This has already been addressed in https://github.com/krzyzanowskim/OpenSSL/pull/41 but got broken again.

I'Ve fixed this issue for all versions of the file.