### PR TITLE
Support ARM64 macOS builds

### DIFF
--- a/OpenSSL.xcconfig
+++ b/OpenSSL.xcconfig
@@ -1,0 +1,3 @@
+// 2020-07-09: Xcode 12 beta does not support ARM64 simulator yet.
+ARCHS[sdk=iphonesimulator*]=i386 x86_64
+VALID_ARCHS[sdk=iphonesimulator*]=i386 x86_64

--- a/OpenSSL.xcodeproj/project.pbxproj
+++ b/OpenSSL.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -90,8 +90,8 @@
 		9F4A2701223BD8DB005CB63A /* ebcdic.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A26B6223BD8DB005CB63A /* ebcdic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F4A2702223BD8DB005CB63A /* bn.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A26B7223BD8DB005CB63A /* bn.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F4A2703223BD8DB005CB63A /* krb5_asn.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A26B8223BD8DB005CB63A /* krb5_asn.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F4A2707223BD900005CB63A /* libssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A2705223BD900005CB63A /* libssl.a */; };
-		9F4A2708223BD900005CB63A /* libcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A2706223BD900005CB63A /* libcrypto.a */; };
+		9F4A2707223BD900005CB63A /* libssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A2705223BD900005CB63A /* libssl.a */; platformFilter = ios; };
+		9F4A2708223BD900005CB63A /* libcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A2706223BD900005CB63A /* libcrypto.a */; platformFilter = ios; };
 		9F4A270E223BD9EB005CB63A /* OpenSSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A270D223BD9EB005CB63A /* OpenSSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F4A2723223BE516005CB63A /* OpenSSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A271F223BE4E6005CB63A /* OpenSSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F4A2771223BE55A005CB63A /* seed.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A2726223BE554005CB63A /* seed.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -182,6 +182,7 @@
 		75F1C98B22BE87E600F44E23 /* shim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = shim.h; path = macos/include/openssl/shim.h; sourceTree = "<group>"; };
 		75F1C98E22BE881200F44E23 /* shim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = shim.h; path = ios/include/openssl/shim.h; sourceTree = "<group>"; };
 		84BBFB572331B8D200DD11C1 /* opensslconf-i386.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "opensslconf-i386.h"; path = "ios/include/openssl/opensslconf-i386.h"; sourceTree = "<group>"; };
+		863B6DD424B83C2D002E03CC /* OpenSSL.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = OpenSSL.xcconfig; sourceTree = "<group>"; };
 		9F4A265C223BD82B005CB63A /* OpenSSL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OpenSSL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F4A266E223BD8D5005CB63A /* mdc2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mdc2.h; path = ios/include/openssl/mdc2.h; sourceTree = "<group>"; };
 		9F4A266F223BD8D5005CB63A /* aes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = aes.h; path = ios/include/openssl/aes.h; sourceTree = "<group>"; };
@@ -369,6 +370,7 @@
 		9F4A2626223BCE31005CB63A = {
 			isa = PBXGroup;
 			children = (
+				863B6DD424B83C2D002E03CC /* OpenSSL.xcconfig */,
 				9F4A266C223BD8BD005CB63A /* OpenSSL (iOS) */,
 				9F4A271E223BE4D3005CB63A /* OpenSSL (macOS) */,
 				9F4A264F223BD6C6005CB63A /* Products */,
@@ -883,12 +885,14 @@
 /* Begin XCBuildConfiguration section */
 		9F4A262B223BCE31005CB63A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 863B6DD424B83C2D002E03CC /* OpenSSL.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
 		9F4A262C223BCE31005CB63A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 863B6DD424B83C2D002E03CC /* OpenSSL.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;


### PR DESCRIPTION
This provides basic support for building OpenSSL on macOS for ARM64 as well.

This pull request needs to make a number of changes:

* First, a check whether to actually compile for macOS ARM64 is made, based on the SDK version.
  * This is not completely correct right now as Apple provides two Xcode 12 betas, one with macOS ARM64 support and one without. But the final Xcode release is going to be just one Xcode build which supports everything.
* The build directories and logs, which previously were only differentiated by architecture, now also include the OS in their names (e.g. `1.0.2u-MacOSX-arm64.build.log`) since there are now two (or three) OSs which build for ARM64.
* While I was at it, I also split up the log files into `.config.` and `.build.` so that the later doesn't overwrite the former any more.
* There's no `darwin64-arm64-cc` target in OpenSSL, but `iphone-cross` seems to work just fine when given the macOS SDK.
* The macOS build process has been moved into `build()` and that function was refactored a bit.
* `build()`'s second argument is now repurposed (and renamed) to `OS` as the `SDK` wasn't needed at that point any more, but `OS` was.
* I needed to introduce a config file for Xcode, `OpenSSL.xcconfig`, to work around a current limitation in Xcode 12 beta (see below).

### Known issues/limitations

* Xcode 12 beta does not support building iPhoneSimulator for ARM64 yet.
  * The build script has a dedicated variable `BUILD_IPHONESIMULATOR_ARM64` because of that. It's currently never set, once Xcode does support building iPhoneSimulator for ARM64 we can set it.
  * However, we would need to solve a conflict in the headers between iOS ARM64 and iPhoneSimulator ARM64 then. Haven't bothered to do this yet since it's possible Apple never support iPhoneSimulator ARM64 since ARM-based Macs are going to be able to run iOS apps natively.
  * Xcode needs to be told not to try to link iPhoneSimulator ARM64. That's what the `OpenSSL.xcconfig` is for.
* In my builds, the iOS `libcrypto.a` and `libssl.a` contain the armv7s architecture, but the final `OpenSSL.framework` does not. I don't know why, yet.
* Xcode 12 only supports minimum deployment targets of iOS 9.0 (IIRC) and macOS 10.9. The binaries do contain the entries for iOS 8.0 and macOS 10.8 but it might be a good idea to raise the deployment targets in the project and podspec.