### PR TITLE
Fix macOS deployment target

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,6 +23,7 @@ IPHONESIMULATOR_SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
 
 OSX_SDK_VERSION=$(xcrun --sdk macosx --show-sdk-version)
 export OSX_DEPLOYMENT_VERSION="10.10"
+export MACOSX_DEPLOYMENT_TARGET="10.10"
 export OSX_SDK=$(xcrun --sdk macosx --show-sdk-path)
 
 # Turn versions like 1.2.3 into numbers that can be compare by bash.


### PR DESCRIPTION
The macOS deployment target appears to be macOS 11.0, not macOS 10.10 as it says in the code. This applies both to the included binaries and compiling them yourself.

With the included fix the macOS deployment target after compiling reflects the code.

I have not included the updated binaries because you probably want to compile them yourself. Also, I have not tested if the line `export OSX_DEPLOYMENT_VERSION="10.10"` is superfluous now or if other environment variables are affected.