### PR TITLE
Add support for static frameworks / XCFramework in create-frameworks.sh

### DIFF
--- a/scripts/create-frameworks.sh
+++ b/scripts/create-frameworks.sh
@@ -3,11 +3,20 @@
 set -e
 # set -x
 
+XC_USER_DEFINED_VARS=""
+
+while getopts ":s" option; do
+   case $option in
+      s) # Build XCFramework as static instead of dynamic
+         XC_USER_DEFINED_VARS="MACH_O_TYPE=staticlib"
+   esac
+done
+
 BASE_PWD="$PWD"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 FWNAME="OpenSSL"
 OUTPUT_DIR=$( mktemp -d )
-COMMON_SETUP=" -project ${SCRIPT_DIR}/../${FWNAME}.xcodeproj -configuration Release -quiet BUILD_LIBRARY_FOR_DISTRIBUTION=YES "
+COMMON_SETUP=" -project ${SCRIPT_DIR}/../${FWNAME}.xcodeproj -configuration Release -quiet BUILD_LIBRARY_FOR_DISTRIBUTION=YES $XC_USER_DEFINED_VARS"
 
 # macOS
 DERIVED_DATA_PATH=$( mktemp -d )


### PR DESCRIPTION
The problem: `create-frameworks.sh` is limited to producing dynamic libraries. In use cases that make sense, static linking can lead to better optimization.

This adds a simple flag to `create-frameworks.sh`, `-s`, which overrides the mach-o format to instead be a static library. The resulting output frameworks, along with the final XCFramework, are produced as static libraries instead of dynamic libraries. Since the existing `OpenSSL.framework` is already just a simple repackaging of the `libcrypto` and `libssl` libraries, I don't believe that anything else needs to be touched.

Examples:

```sh
./scripts/create-frameworks.sh # Builds dynamic frameworks / dynamic XCFramework, as usual
./scripts/create-frameworks.sh -s # Builds static frameworks / static XCFramework
```

No worries if you'd prefer a different approach, or if this isn't in the scope of this project.