### PR TITLE
Update OpenSSL 1.1.1p

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # Setup paths to stuff we need
 
-OPENSSL_VERSION="1.1.1o"
+OPENSSL_VERSION="1.1.1p"
 export OPENSSL_LOCAL_CONFIG_DIR="${SCRIPT_DIR}/../config"
 
 DEVELOPER=$(xcode-select --print-path)


### PR DESCRIPTION
Hello @krzyzanowskim,

this PR simply updates to `OpenSSL 1.1.1p` (https://www.openssl.org/news/openssl-1.1.1-notes.html)

Kind regards,
Andy ✌️
