### PR TITLE
Adjust zip to support binaryTarget when using SPM

### DIFF
--- a/scripts/create-frameworks.sh
+++ b/scripts/create-frameworks.sh
@@ -99,6 +99,8 @@ xcrun xcodebuild -quiet -create-xcframework \
 	-output "${BASE_PWD}/Frameworks/${FWNAME}.xcframework"
 
 # Zip archive
-zip --symlinks -r "${BASE_PWD}/Frameworks/${FWNAME}.xcframework.zip" "${BASE_PWD}/Frameworks/${FWNAME}.xcframework"
+pushd "${BASE_PWD}/Frameworks"
+zip --symlinks -r "./${FWNAME}.xcframework.zip" "./${FWNAME}.xcframework"
+popd
 
-rm -rf ${OUTPUT_DIR}
+rm -rf "${OUTPUT_DIR}"


### PR DESCRIPTION
Hello,

first of all **thanks for maintaining this project.**

## The problem

Currently when using SPM the README suggests to add OpenSSL as a dependency. This will cause SPM to download the whole git repository (which is quite large).
To get around that SPM provides the binaryTarget option which also can download remote files via URL. But when trying to use the latest zip file from the releases page, this will not work because of the folder structure inside the zip file.

The latest release looks like this:
<img width="727" alt="image" src="https://user-images.githubusercontent.com/19751149/183054110-4b6586e8-9de2-440d-a84d-415575ccad08.png">

As you can see the zip contains the whole path to the frameworks of the person who has build the frameworks.

## The change

With my change the path will be changed to the Frameworks folder before zip-ing the frameworks. 

<img width="712" alt="image" src="https://user-images.githubusercontent.com/19751149/183055444-5875de6b-f107-4ca4-ae4a-3c60d39cad33.png">

With that the zip can be used as a binaryTarget. Tested only locally so far.

To enrich the usage even further I would love to see a checksum provided which is required when using binaryTarget with a remote URL. At-present getting the checksum requires to download the zip and compute the checksum manually. Having a checksum provided in the release notes would be helpful.

The checksum can be generated with the following command.

```bash
swift package compute-checksum Frameworks/OpenSSL.xcframework.zip
```

If wanted I would suggest to add this as an output to the `create-frameworks.sh` script for easy copy and paste after building. If there is an automated release process/script, this could also be implemented there.

Please feel free to reach out to me for any questions or feedback. Thanks again for your work :)
