### PR TITLE
feat: Privacy Manifest And xcframework Sign

### DIFF
--- a/scripts/create-frameworks.sh
+++ b/scripts/create-frameworks.sh
@@ -14,6 +14,7 @@ done
 
 BASE_PWD="$PWD"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+IDENTITY=$1
 FWNAME="OpenSSL"
 OUTPUT_DIR=$( mktemp -d )
 COMMON_SETUP=" -project ${SCRIPT_DIR}/../${FWNAME}.xcodeproj -configuration Release BUILD_LIBRARY_FOR_DISTRIBUTION=YES $XC_USER_DEFINED_VARS"
@@ -97,6 +98,8 @@ xcrun xcodebuild -create-xcframework \
 	-framework "${BASE_PWD}/Frameworks/macosx/${FWNAME}.framework" \
 	-framework "${BASE_PWD}/Frameworks/macosx_catalyst/${FWNAME}.framework" \
 	-output "${BASE_PWD}/Frameworks/${FWNAME}.xcframework"
+ 
+ xcrun codesign --timestamp -s ${IDENTITY} ${FWNAME}.xcframework
 
 # Zip archive
 pushd "${BASE_PWD}/Frameworks"

--- a/scripts/create-frameworks.sh
+++ b/scripts/create-frameworks.sh
@@ -99,7 +99,7 @@ xcrun xcodebuild -create-xcframework \
 	-framework "${BASE_PWD}/Frameworks/macosx_catalyst/${FWNAME}.framework" \
 	-output "${BASE_PWD}/Frameworks/${FWNAME}.xcframework"
  
- xcrun codesign --timestamp -s ${IDENTITY} ${BASE_PWD}/Frameworks/${FWNAME}.xcframework
+ xcrun codesign --timestamp -s "${IDENTITY}" "${BASE_PWD}/Frameworks/${FWNAME}.xcframework"
 
 # Zip archive
 pushd "${BASE_PWD}/Frameworks"

--- a/scripts/create-frameworks.sh
+++ b/scripts/create-frameworks.sh
@@ -99,7 +99,7 @@ xcrun xcodebuild -create-xcframework \
 	-framework "${BASE_PWD}/Frameworks/macosx_catalyst/${FWNAME}.framework" \
 	-output "${BASE_PWD}/Frameworks/${FWNAME}.xcframework"
  
- xcrun codesign --timestamp -s ${IDENTITY} ${FWNAME}.xcframework
+ xcrun codesign --timestamp -s ${IDENTITY} ${BASE_PWD}/Frameworks/${FWNAME}.xcframework
 
 # Zip archive
 pushd "${BASE_PWD}/Frameworks"

--- a/support/ios/PrivacyInfo.xcprivacy
+++ b/support/ios/PrivacyInfo.xcprivacy
@@ -6,7 +6,14 @@
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
-		<dict/>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>DDA9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>File Timestamp</string>
+		</dict>
 	</array>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>

--- a/support/iphonesimulator/PrivacyInfo.xcprivacy
+++ b/support/iphonesimulator/PrivacyInfo.xcprivacy
@@ -6,7 +6,14 @@
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
-		<dict/>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>DDA9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>File Timestamp</string>
+		</dict>
 	</array>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>

--- a/support/macos/PrivacyInfo.xcprivacy
+++ b/support/macos/PrivacyInfo.xcprivacy
@@ -6,7 +6,14 @@
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
-		<dict/>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>DDA9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>File Timestamp</string>
+		</dict>
 	</array>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>

--- a/support/macos_catalyst/PrivacyInfo.xcprivacy
+++ b/support/macos_catalyst/PrivacyInfo.xcprivacy
@@ -6,7 +6,14 @@
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
-		<dict/>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>DDA9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>File Timestamp</string>
+		</dict>
 	</array>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>


### PR DESCRIPTION
- OpenSSL utilizes `stat`, `fstat` and `lstat`, which must be declared in the PrivacyInfo.xcprivacy files under the category `NSPrivacyAccessedAPICategoryFileTimestamp`

reference:
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393

- Starting from May 1st, `xcframeworks` must also be signed. I've added a parameter in the create-frameworks.sh script where you can provide your apple signing identity.

reference: 
https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle#Sign-the-XCFramework-bundle
