### PR TITLE
Workaround for Xcode 16.0 Beta uint64_t problem

### DIFF
--- a/support/appletvos/OpenSSL.h
+++ b/support/appletvos/OpenSSL.h
@@ -1,3 +1,6 @@
+// Because build problem with Xcode 16.0 Beta
+#include <_types/_uint64_t.h>
+
 // ls -1 ../../appletvsimulator/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:
 #include <OpenSSL/ssl.h>

--- a/support/appletvos/OpenSSL.h
+++ b/support/appletvos/OpenSSL.h
@@ -1,5 +1,7 @@
 // Because build problem with Xcode 16.0 Beta
+#ifndef uint64_t
 #include <_types/_uint64_t.h>
+#endif
 
 // ls -1 ../../appletvsimulator/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:

--- a/support/appletvsimulator/OpenSSL.h
+++ b/support/appletvsimulator/OpenSSL.h
@@ -1,5 +1,7 @@
 // Because build problem with Xcode 16.0 Beta
+#ifndef uint64_t
 #include <_types/_uint64_t.h>
+#endif
 
 // ls -1 ../../appletvos/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:

--- a/support/appletvsimulator/OpenSSL.h
+++ b/support/appletvsimulator/OpenSSL.h
@@ -1,3 +1,6 @@
+// Because build problem with Xcode 16.0 Beta
+#include <_types/_uint64_t.h>
+
 // ls -1 ../../appletvos/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:
 #include <OpenSSL/ssl.h>

--- a/support/iphoneos/OpenSSL.h
+++ b/support/iphoneos/OpenSSL.h
@@ -1,5 +1,7 @@
 // Because build problem with Xcode 16.0 Beta
+#ifndef uint64_t
 #include <_types/_uint64_t.h>
+#endif
 
 // ls -1 ../../iphoneos/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:

--- a/support/iphoneos/OpenSSL.h
+++ b/support/iphoneos/OpenSSL.h
@@ -1,3 +1,6 @@
+// Because build problem with Xcode 16.0 Beta
+#include <_types/_uint64_t.h>
+
 // ls -1 ../../iphoneos/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:
 #include <OpenSSL/ssl.h>

--- a/support/iphonesimulator/OpenSSL.h
+++ b/support/iphonesimulator/OpenSSL.h
@@ -1,5 +1,7 @@
 // Because build problem with Xcode 16.0 Beta
+#ifndef uint64_t
 #include <_types/_uint64_t.h>
+#endif
 
 // Include before others:
 #include <OpenSSL/ssl.h>

--- a/support/iphonesimulator/OpenSSL.h
+++ b/support/iphonesimulator/OpenSSL.h
@@ -1,3 +1,6 @@
+// Because build problem with Xcode 16.0 Beta
+#include <_types/_uint64_t.h>
+
 // Include before others:
 #include <OpenSSL/ssl.h>
 

--- a/support/macos/OpenSSL.h
+++ b/support/macos/OpenSSL.h
@@ -1,5 +1,7 @@
 // Because build problem with Xcode 16.0 Beta
+#ifndef uint64_t
 #include <_types/_uint64_t.h>
+#endif
 
 // Include before others:
 #include <OpenSSL/ssl.h>

--- a/support/macos/OpenSSL.h
+++ b/support/macos/OpenSSL.h
@@ -1,3 +1,6 @@
+// Because build problem with Xcode 16.0 Beta
+#include <_types/_uint64_t.h>
+
 // Include before others:
 #include <OpenSSL/ssl.h>
 

--- a/support/macos_catalyst/OpenSSL.h
+++ b/support/macos_catalyst/OpenSSL.h
@@ -1,5 +1,7 @@
 // Because build problem with Xcode 16.0 Beta
+#ifndef uint64_t
 #include <_types/_uint64_t.h>
+#endif
 
 // Include before others:
 #include <OpenSSL/ssl.h>

--- a/support/macos_catalyst/OpenSSL.h
+++ b/support/macos_catalyst/OpenSSL.h
@@ -1,3 +1,6 @@
+// Because build problem with Xcode 16.0 Beta
+#include <_types/_uint64_t.h>
+
 // Include before others:
 #include <OpenSSL/ssl.h>
 

--- a/support/visionos/OpenSSL.h
+++ b/support/visionos/OpenSSL.h
@@ -1,3 +1,6 @@
+// Because build problem with Xcode 16.0 Beta
+#include <_types/_uint64_t.h>
+
 // ls -1 ../../visionos/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:
 #include <OpenSSL/ssl.h>

--- a/support/visionos/OpenSSL.h
+++ b/support/visionos/OpenSSL.h
@@ -1,5 +1,7 @@
 // Because build problem with Xcode 16.0 Beta
+#ifndef uint64_t
 #include <_types/_uint64_t.h>
+#endif
 
 // ls -1 ../../visionos/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:

--- a/support/visionsimulator/OpenSSL.h
+++ b/support/visionsimulator/OpenSSL.h
@@ -1,5 +1,7 @@
 // Because build problem with Xcode 16.0 Beta
+#ifndef uint64_t
 #include <_types/_uint64_t.h>
+#endif
 
 // ls -1 ../../visionsimulator/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:

--- a/support/visionsimulator/OpenSSL.h
+++ b/support/visionsimulator/OpenSSL.h
@@ -1,3 +1,6 @@
+// Because build problem with Xcode 16.0 Beta
+#include <_types/_uint64_t.h>
+
 // ls -1 ../../visionsimulator/include/openssl | sed 's/\(.*\)/\#include \<OpenSSL\/\1\>/'
 // Include before others:
 #include <OpenSSL/ssl.h>


### PR DESCRIPTION
Workaround for Xcode 16.0 Beta problem with uint64_t by adding import to umbrella headers