### PR TITLE
Fix Xcode warnings

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -181,6 +181,12 @@ build_ios() {
    echo "#elif defined(__APPLE__) && defined (__arm64__)" >> ${OPENSSLCONF_PATH}
    cat ${TMP_BUILD_DIR}/${OPENSSL_VERSION}-iPhoneOS-arm64/include/openssl/opensslconf.h >> ${OPENSSLCONF_PATH}
    echo "#endif" >> ${OPENSSLCONF_PATH}
+   
+   # fix RC4_INT redefinition
+   find "${SCRIPT_DIR}/../iphoneos/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned int/\#undef RC4_INT\n#define RC4_INT unsigned int/g" {} \;
+   find "${SCRIPT_DIR}/../iphoneos/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned char/\#undef RC4_INT\n#define RC4_INT unsigned char/g" {} \;
+   find "${SCRIPT_DIR}/../iphonesimulator/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned int/\#undef RC4_INT\n#define RC4_INT unsigned int/g" {} \;
+   find "${SCRIPT_DIR}/../iphonesimulator/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned char/\#undef RC4_INT\n#define RC4_INT unsigned char/g" {} \;
 
    rm -rf ${TMP_BUILD_DIR}
 }
@@ -213,6 +219,10 @@ build_macos() {
    echo "#elif defined(__APPLE__) && defined (__arm64__)" >> ${OPENSSLCONF_PATH}
    cat ${TMP_BUILD_DIR}/${OPENSSL_VERSION}-MacOSX-arm64/include/openssl/opensslconf.h >> ${OPENSSLCONF_PATH}
    echo "#endif" >> ${OPENSSLCONF_PATH}
+   
+   # fix RC4_INT redefinition
+   find "${SCRIPT_DIR}/../macosx/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned int/\#undef RC4_INT\n#define RC4_INT unsigned int/g" {} \;
+   find "${SCRIPT_DIR}/../macosx/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned char/\#undef RC4_INT\n#define RC4_INT unsigned char/g" {} \;
 
    rm -rf ${TMP_BUILD_DIR}
 }
@@ -235,15 +245,16 @@ build_catalyst() {
    # fix inttypes.h
    find "${SCRIPT_DIR}/../macosx_catalyst/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/include <inttypes\.h>/include <sys\/types\.h>/g" {} \;
 
-   # fix RC4_INT redefinition
-   # find "${SCRIPT_DIR}/../macosx/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned char/\#if \!defined(RC4_INT)\n#define RC4_INT unsigned char\n\#endif\n/g" {} \;
-
    local OPENSSLCONF_PATH="${SCRIPT_DIR}/../macosx_catalyst/include/openssl/opensslconf.h"
    echo "#if defined(__APPLE__) && defined (__x86_64__)" >> ${OPENSSLCONF_PATH}
    cat ${TMP_BUILD_DIR}/${OPENSSL_VERSION}-MacOSX_Catalyst-x86_64/include/openssl/opensslconf.h >> ${OPENSSLCONF_PATH}
    echo "#elif defined(__APPLE__) && defined (__arm64__)" >> ${OPENSSLCONF_PATH}
    cat ${TMP_BUILD_DIR}/${OPENSSL_VERSION}-MacOSX_Catalyst-arm64/include/openssl/opensslconf.h >> ${OPENSSLCONF_PATH}
    echo "#endif" >> ${OPENSSLCONF_PATH}
+
+   # fix RC4_INT redefinition
+   find "${SCRIPT_DIR}/../macosx_catalyst/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned int/\#undef RC4_INT\n#define RC4_INT unsigned int/g" {} \;
+   find "${SCRIPT_DIR}/../macosx_catalyst/include/openssl" -type f -name "*.h" -exec sed -i "" -e "s/\#define RC4_INT unsigned char/\#undef RC4_INT\n#define RC4_INT unsigned char/g" {} \;
 
    rm -rf ${TMP_BUILD_DIR}
 }

--- a/shim/shim.h
+++ b/shim/shim.h
@@ -9,28 +9,28 @@
 #include <openssl/cms.h>
 
 #undef SSL_library_init
-static inline void SSL_library_init() {
+static inline void SSL_library_init(void) {
     OPENSSL_init_ssl(0, NULL);
 }
 
 #undef SSL_load_error_strings
-static inline void SSL_load_error_strings() {
+static inline void SSL_load_error_strings(void) {
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS \
                      | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 }
 
 #undef OpenSSL_add_all_ciphers
-static inline void OpenSSL_add_all_ciphers() {
+static inline void OpenSSL_add_all_ciphers(void) {
     OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS, NULL);
 }
 
 #undef OpenSSL_add_all_digests
-static inline void OpenSSL_add_all_digests() {
+static inline void OpenSSL_add_all_digests(void) {
     OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_DIGESTS, NULL);
 }
 
 #undef OpenSSL_add_all_algorithms
-static inline void OpenSSL_add_all_algorithms() {
+static inline void OpenSSL_add_all_algorithms(void) {
     #ifdef OPENSSL_LOAD_CONF
     OPENSSL_add_all_algorithms_conf();
     #else


### PR DESCRIPTION
Thanks again for this project!

We are still running on the support branch and see various warnings in Xcode.
The former one was fixed at some point (059945d717ebaf7817f7a8ff58e387941b36886b), but that fix has been removed later, I don't know why. Since `RC4_INT ` is sometimes defined as `int` and sometimes as `char`, I decided to let the last define win. Not sure if that is correct though.

The second warning has been [fixed recently](https://github.com/krzyzanowskim/OpenSSL/pull/177). 

<img width="520" alt="Screenshot 2024-07-04 at 22 51 21" src="https://github.com/krzyzanowskim/OpenSSL/assets/11056766/f3d7d6b6-2a2e-40ba-a9af-8590f100a170">
